### PR TITLE
Added flex-basis to flex-size (equal as size) for IE 11 .

### DIFF
--- a/system/size.js
+++ b/system/size.js
@@ -1,32 +1,33 @@
-class Size{
-    
+class Size {
+
     constructor(resources, name, postfix = '') {
         this.resources = resources;
         this.name = postfix === '' ? name : name + '-' + postfix;
         this.postfix = postfix;
     }
-    
-    render(){
+
+    render() {
         let style = '';
         let mediaPostfix = this.postfix === '' ? '' : '_' + this.postfix;
 
-        if(this.resources.helpers.isPercentage(this.resources.settings.offset)){
+        if (this.resources.helpers.isPercentage(this.resources.settings.offset)) {
             style += this.resources.styles.objToCallMedia(this.postfix, {
                 width: `{{var}}atom * {{var}}n - {{var}}offset${mediaPostfix}`
             });
-        }
-        else if(this.resources.settings.detailedCalc){
+        } else if (this.resources.settings.detailedCalc) {
             style += `{{var}}val{{=}}{{i}}calc(100% / {{string-var}}columns{{/string-var}} * {{string-var}}n{{/string-var}} - {{string-var}}offset${mediaPostfix}{{/string-var}}){{/i}}{{;}}\n`;
-            
+
             style += this.resources.styles.objToCallMedia(this.postfix, {
                 width: '{{var}}val'
             });
-        }
-        else{
+        } else {
             style += `{{var}}val{{=}}100% / {{var}}columns * {{var}}n{{;}}\n`;
-            
+
             style += this.resources.styles.objToCallMedia(this.postfix, {
                 width: `{{i}}calc({{string-var}}val{{/string-var}} - {{string-var}}offset${mediaPostfix}{{/string-var}}){{/i}}`
+            });
+            style += this.resources.styles.objToCallMedia(this.postfix, {
+                'flex-basis': `{{i}}calc({{string-var}}val{{/string-var}} - {{string-var}}offset${mediaPostfix}{{/string-var}}){{/i}}`
             });
         }
 


### PR DESCRIPTION
Sometimes IE need flex-basis for correct width.


Столкнулся с проблемой в IE11 . Пользуюсь smart-grid + vuetify (vue.js библиотека).
Обычно , сетка отрабатывает на 5 + в IE, но если внутри флекс-айтема  у нас будет компонент <v-card> (из Вьютифай), внутри которого не будет задана ширина в пикселях  - оно растягивает блоки на 100% (хотя указано , например 16% - gutter). Погуглив, узнал что проблема в IE, если нет фиксированной ширины в пикселях - ему надо помочь , и прописать flex-basis, туда-же , где и записана ширина.